### PR TITLE
Enable CI tests

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -1,0 +1,57 @@
+name: 'Testing'
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: arn:aws:iam::270074865685:role/terraform-module-ci-test
+        role-session-name: ${{env.GITHUB_JOB}}-${{env.GITHUB_RUN_ID}}-${{env.GITHUB_RUN_NUMBER}}-${{env.GITHUB_RUN_ATTEMPT}}
+        aws-region: us-west-1
+      
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 1.5.3
+        with_wrapper: false
+
+    - name: Terraform Init
+      run: cd examples/basic && terraform init
+      
+    - name: Terraform Plan
+      run: cd examples/basic && terraform init && terraform plan
+  
+  terratest:
+    name: 'Terratest'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: arn:aws:iam::270074865685:role/terraform-module-ci-test
+        role-session-name: ${{env.GITHUB_JOB}}-${{env.GITHUB_RUN_ID}}-${{env.GITHUB_RUN_NUMBER}}-${{env.GITHUB_RUN_ATTEMPT}}
+        aws-region: ${{env.AWS_REGION}}
+
+    - name: Run Terratest
+      run: cd tests && go test -v -timeout=30m -parallel=10

--- a/.github/workflows/pr_tests.yaml
+++ b/.github/workflows/pr_tests.yaml
@@ -3,7 +3,7 @@ name: 'Testing'
 on:
   pull_request:
     branches:
-    - main 
+      - main
 
 jobs:
   terraform:
@@ -19,18 +19,8 @@ jobs:
         terraform_version: 1.5.3
         with_wrapper: false
 
-    - name: Terraform Init
+    - name: Init Basic
       run: cd examples/basic && terraform init
-      
-    - name: Terraform Plan
-      run: cd examples/basic && terraform init && terraform plan
-  
-  terratest:
-    name: 'Terratest'
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
 
-    - name: Run Terratest
-      run: cd tests && go test -v -timeout=30m -parallel=10
+    - name: Validate Basic
+      run: cd examples/basic && terraform validate


### PR DESCRIPTION
This allows tests to run in a reasonable way.
Separate out full tests and pr tests, auth with aws using oidc for integration or e2e testing
